### PR TITLE
Updated DDL.sql - MeasurementRecord Table

### DIFF
--- a/ddl.sql
+++ b/ddl.sql
@@ -193,7 +193,7 @@ CREATE TABLE MeasurementRecord(
     DateTimeRecorded DATETIME NOT NULL,
     MeasurementID INT NOT NULL,
     CategoryID INT NOT NULL,
-    HospitalNumber NVARCHAR(50) NOT NULL
+    HospitalNumber NVARCHAR(50) NOT NULL,
     CONSTRAINT PK_MeasurementRecord PRIMARY KEY (MeasurementRecordID),
     CONSTRAINT UQ_MeasurementRecord UNIQUE(DateTimeRecorded, MeasurementID, CategoryID, HospitalNumber),
     CONSTRAINT FK_MeasurementRecord_PatientMeasurement FOREIGN KEY (MeasurementID, CategoryID, HospitalNumber) REFERENCES PatientMeasurement (MeasurementID, CategoryID, HospitalNumber)

--- a/ddl.sql
+++ b/ddl.sql
@@ -210,7 +210,7 @@ CREATE TABLE DataPointRecord(
     MeasurementRecordID INT NOT NULL,
     CONSTRAINT PK_DataPointRecord PRIMARY KEY (HospitalNumber, CategoryID, MeasurementID, DataPointNumber),
     CONSTRAINT FK_DataPointRecord_DataPoint FOREIGN KEY (MeasurementID, DataPointNumber) REFERENCES DataPoint (MeasurementID, DataPointNumber),
-    CONSTRAINT FK_DataPointRecord_MeasurementRecord FOREIGN KEY (MeasurementRecordID, MeasurementID, CategoryID, HospitalNumber) REFERENCES MeasurementRecord (MeasurementRecordID, MeasurementID, CategoryID, HospitalNumber)
+    CONSTRAINT FK_DataPointRecord_MeasurementRecord FOREIGN KEY (MeasurementRecordID) REFERENCES MeasurementRecord (MeasurementRecordID)
 )
 
 GO

--- a/ddl.sql
+++ b/ddl.sql
@@ -193,8 +193,9 @@ CREATE TABLE MeasurementRecord(
     DateTimeRecorded DATETIME NOT NULL,
     MeasurementID INT NOT NULL,
     CategoryID INT NOT NULL,
-    HospitalNumber NVARCHAR(50) NOT NULL,
-    CONSTRAINT PK_MeasurementRecord PRIMARY KEY (MeasurementRecordID, MeasurementID, CategoryID, HospitalNumber),
+    HospitalNumber NVARCHAR(50) NOT NULL
+    CONSTRAINT PK_MeasurementRecord PRIMARY KEY (MeasurementRecordID),
+    CONSTRAINT UQ_MeasurementRecord UNIQUE(DateTimeRecorded, MeasurementID, CategoryID, HospitalNumber),
     CONSTRAINT FK_MeasurementRecord_PatientMeasurement FOREIGN KEY (MeasurementID, CategoryID, HospitalNumber) REFERENCES PatientMeasurement (MeasurementID, CategoryID, HospitalNumber)
 )
 


### PR DESCRIPTION
Corrects surrogate key so it replaces the natural key, instead of adding to or extending it.

Because of use of surrogate key the natural key is no longer designated as a PK and so the uniqueness of this combination is no longer enforced
added the necessary unique constraint to maintain the integity of the natural data